### PR TITLE
Fixes small bug due to sample rate literal resulting in out of bounds…

### DIFF
--- a/src/mfcc/MFCC.cpp
+++ b/src/mfcc/MFCC.cpp
@@ -163,7 +163,7 @@ void MFCC<T>::calculateMelFilterBank()
         double f = i * (maxMel - minMel) / (numCoefficents + 1) + minMel;
 
         double tmp = log (1 + 1000.0 / 700.0) / 1000.0;
-        tmp = (exp (f * tmp) - 1) / 22050;
+        tmp = (exp (f * tmp) - 1) / (samplingFrequency / 2);
 
         tmp = 0.5 + 700 * ((double)magnitudeSpectrumSize) * tmp;
 


### PR DESCRIPTION
… access on sample rate change

Hi Adam,

I was encountering a segfault/crash when using Gist in an audio plugin and tracked it down to the MFCC class. I think it's being caused by the hard-coded/literal value for the sample rate in the calculateMelFilterBank function. If the sample rate is changed to say 48000fs this literal was resulting in an out of bounds memory access issue further down where the triangle windowing is calculated. Crash would occur on destruction when the plugin was unloaded and also on the first load of a fresh build of the plugin.

Stack trace for the crash included below:
#0 0x00007fe899a05bd6 in _int_free (av=0x7fe899d49b20 , p=, have_lock=0) at malloc.c:4015
#1 0x00007fe899a09abc in __GI___libc_free (mem=) at malloc.c:2969
#2 0x00007fe892a7a7f0 in __gnu_cxx::new_allocator::deallocate (this=0x20c4648,

__p=0x20cd790) at /usr/include/c++/5/ext/new_allocator.h:110
#3 0x00007fe892a79f9e in std::allocator_traitsstd::allocator<float >::deallocate (__a=...,

__p=0x20cd790, __n=128) at /usr/include/c++/5/bits/alloc_traits.h:517
#4 0x00007fe892a78edc in std::_Vector_base >::_M_deallocate (

this=0x20c4648, __p=0x20cd790, __n=128) at /usr/include/c++/5/bits/stl_vector.h:178
#5 0x00007fe892a778c9 in std::_Vector_base >::~_Vector_base (

this=0x20c4648, __in_chrg=) at /usr/include/c++/5/bits/stl_vector.h:160
#6 0x00007fe892a76e87 in std::vector >::~vector (this=0x20c4648,

__in_chrg=) at /usr/include/c++/5/bits/stl_vector.h:425
#7 0x00007fe892a7a7cd in std::_Destroy > > (

__pointer=0x20c4648) at /usr/include/c++/5/bits/stl_construct.h:93
#8 0x00007fe892a79f69 in std::_Destroy_aux::__destroy >> (__first=0x20c4648, __last=0x20c4678) at /usr/include/c++/5/bits/stl_construct.h:103
#9 0x00007fe892a78e68 in std::_Destroy >> (

__first=0x20c4540, __last=0x20c4678) at /usr/include/c++/5/bits/stl_construct.h:126
#10 0x00007fe892a7784d in std::_Destroy >*, std::vector > > (__first=0x20c4540, __last=0x20c4678) at /usr/include/c++/5/bits/stl_construct.h:151
#11 0x00007fe892a76e1b in std::vector >, std::allocator > > >::~vector (this=0x20c40f8, __in_chrg=) at /usr/include/c++/5/bits/stl_vector.h:424
#12 0x00007fe892a802dc in MFCC::~MFCC (this=0x20c40e0, __in_chrg=) at ../../Source/AudioClassify/Gist/src/mfcc/MFCC.h:35
#13 0x00007fe892a7e119 in Gist::~Gist (this=0x20c3fb0, __in_chrg=) at ../../Source/AudioClassify/Gist/src/Gist.cpp:46

I altered this line to use sampleRate / 2 and the crash stopped occurring. The crash was happening for me on Ubuntu 16.04 using the JUCE plugin host.

Hopefully this is correct/OK.

Josh
